### PR TITLE
[BOJ] 15649 - N과 M(1)

### DIFF
--- a/이지윤/B15649.java
+++ b/이지윤/B15649.java
@@ -22,6 +22,7 @@ public class B15649 {
 
         backtracking(0);
         bw.flush();
+        bw.close();
     }
 
     private static void backtracking(int depth) throws IOException {


### PR DESCRIPTION
## [백준 2750](https://www.acmicpc.net/problem/15649)
### 실버 3

자연수 N과 M이 주어졌을 때, 

1부터 N까지 자연수 중에서 `중복 없이 M개를 고른 수열`을 만족하는 길이가 M인 수열을 모두 구하면 된다.

- 1 ≤ M ≤ N ≤ 8
- 사전 순 증가 순서

## 예제
### 입력
```shell
4 2
```
### 출력
```shell
1 2
1 3
1 4
2 1
2 3
2 4
3 1
3 2
3 4
4 1
4 2
4 3
```