### PR TITLE
[BOJ] 9663번 - N_Queen

### DIFF
--- a/이지윤/B9663.java
+++ b/이지윤/B9663.java
@@ -18,6 +18,7 @@ public class B9663 {
 
         backtracking(0);
         System.out.println(count);
+        sc.close();
     }
 
     private static void backtracking(int row) {


### PR DESCRIPTION
## [백준 9663](https://www.acmicpc.net/problem/9663)
### Gold 4

N x N 체스판 위에 퀸 n개를 서로 공격할 수 없게 놓아야한다.

이때, 퀸을 놓는 방법의 수를 구하면 된다.

- 1 ≤ N < 15

퀸의 이동 방향 : 가로 세로 대각선

## 예제
### 입력
```shell
8
```
### 출력
```shell
92
```