### PR TITLE
[BOJ] 1377 - 버블소트

### DIFF
--- a/이지윤/B1377.java
+++ b/이지윤/B1377.java
@@ -1,0 +1,47 @@
+package 이지윤;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class B1377 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        Element[] arr = new Element[n];
+
+        for (int i = 0; i < n; i++) {
+            int val = Integer.parseInt(br.readLine());
+            arr[i] = new Element(val, i);
+        }
+
+        Arrays.sort(arr);
+
+        int max = 0;
+        for (int i = 0; i < n; i++) {
+            int move = arr[i].index - i;
+            if (move > max) {
+                max = move;
+            }
+        }
+
+        System.out.println(max + 1);
+    }
+
+    private static class Element implements Comparable<Element> {
+        private final int value;
+        private final int index;
+
+        public Element(int value, int index) {
+            this.value = value;
+            this.index = index;
+        }
+        @Override
+        public int compareTo(Element other) {
+            return Integer.compare(this.value, other.value);
+        }
+    }
+}


### PR DESCRIPTION
## [백준 1377](https://www.acmicpc.net/problem/1377)
### Gold 2

주어진 정수 배열을 버블 정렬로 정렬한다고 할 때, 정렬 과정 중 가장 많은 이동이 필요한 원소가 몇 번째 루프에서 제자리를 찾는지 묻는 문제이다.
> 근데 진짜 버블 정렬 구하면 안된다.

## 예제
### 입력
```shell
5
10
1
5
2
3
```

### 출력
```shell
3
```