### PR TITLE
[BOJ] 11403 - 경로 찾기

### DIFF
--- a/이지윤/B11403.java
+++ b/이지윤/B11403.java
@@ -1,0 +1,39 @@
+package 이지윤;
+
+import java.io.*;
+import java.util.*;
+
+public class B11403 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[][] graph = new int[n][n];
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                graph[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        for (int k = 0; k < n; k++) {
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    if (graph[i][k] == 1 && graph[k][j] == 1) {
+                        graph[i][j] = 1;
+                    }
+                }
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int[] row : graph) {
+            for (int col : row) {
+                sb.append(col).append(" ");
+            }
+            sb.append("\n");
+        }
+
+        System.out.print(sb);
+    }
+}


### PR DESCRIPTION
## [백준 11403](https://www.acmicpc.net/problem/11403)
### Silver 1

가중치 없는 방향 그래프 G가 주어졌을 때, 모든 정점 (i, j)에 대해서, i에서 j로 가는 길이가 양수인 경로가 있는지 없는지 구하면 된다.

- N (1 ≤ N ≤ 100)

## 예제
### 입력
```shell
3
0 1 0
0 0 1
1 0 0
```
### 출력
```shell
1 1 1
1 1 1
1 1 1
```
### 입력 2
```shell
7
0 0 0 1 0 0 0
0 0 0 0 0 0 1
0 0 0 0 0 0 0
0 0 0 0 1 1 0
1 0 0 0 0 0 0
0 0 0 0 0 0 1
0 0 1 0 0 0 0
```
### 출력 2
```shell
1 0 1 1 1 1 1
0 0 1 0 0 0 1
0 0 0 0 0 0 0
1 0 1 1 1 1 1
1 0 1 1 1 1 1
0 0 1 0 0 0 1
0 0 1 0 0 0 0
```