### PR TITLE
[BOJ] 1325 - 효율적인 해킹 / 1717 - 집합의 표현

### DIFF
--- a/이지윤/B1325.java
+++ b/이지윤/B1325.java
@@ -1,0 +1,77 @@
+package 이지윤;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class B1325 {
+    static int n, m;
+    static ArrayList<Integer>[] graph;
+    static int[] result;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        graph = new ArrayList[n + 1];
+        result = new int[n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            graph[b].add(a);
+        }
+
+        for (int i = 1; i <= n; i++) {
+            bfs(i);
+        }
+
+        int max = 0;
+        for (int i = 1; i <= n; i++) {
+            if (result[i] > max) {
+                max = result[i];
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= n; i++) {
+            if (result[i] == max) {
+                sb.append(i).append(" ");
+            }
+        }
+        System.out.println(sb.toString().trim());
+    }
+
+    private static void bfs(int start) {
+        boolean[] visited = new boolean[n + 1];
+        Queue<Integer> queue = new LinkedList<>();
+
+        queue.add(start);
+        visited[start] = true;
+        int count = 1;
+
+        while (!queue.isEmpty()) {
+            int current = queue.poll();
+            for (int next : graph[current]) {
+                if (!visited[next]) {
+                    visited[next] = true;
+                    queue.add(next);
+                    count++;
+                }
+            }
+        }
+        result[start] = count;
+    }
+}

--- a/이지윤/B1717.java
+++ b/이지윤/B1717.java
@@ -1,0 +1,61 @@
+package 이지윤;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class B1717 {
+    static int[] parent;
+
+    static int find(int x) {
+        if (parent[x] == x) {
+            return x;
+        }
+        return parent[x] = find(parent[x]);
+    }
+
+    static void union(int a, int b) {
+        int rootA = find(a);
+        int rootB = find(b);
+
+        if (rootA != rootB) {
+            parent[rootB] = rootA;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        parent = new int[n + 1];
+        for (int i = 0; i <= n; i++) {
+            parent[i] = i;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int command = Integer.parseInt(st.nextToken());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            if (command == 0) {
+                union(a, b);
+            } else if (command == 1) {
+                if (find(a) == find(b)) {
+                    sb.append("YES\n");
+                } else {
+                    sb.append("NO\n");
+                }
+            }
+        }
+
+        System.out.print(sb);
+        br.close();
+    }
+}


### PR DESCRIPTION
## [백준 1325](https://www.acmicpc.net/problem/1325)
### Silver 1

신뢰하는 관계일 때 (B → A 간선) 가장 많은 컴퓨터를 해킹할 수 있는 컴퓨터의 번호를 구한다.

- N ≤ 10,000 / M ≤ 100,000
- 오름차순 출력

## 예제
### 입력
```shell
5 4
3 1
3 2
4 3
5 3
```
### 출력
```shell
1 2
```

---

## [백준 1717](https://www.acmicpc.net/problem/1717)
### Gold 5

n+1개의 집합 존재한다. 합집합 연산 (0), 두 원소가 같은 집합에 포함되어있는지 확인하는 연산 (1)을 수행한 후 YES | NO 를 출력한다.

- YES : a와 b가 **같은 집합**에 포함되어있으면
- NO : 위와 반대의 경우

#### 제한 조건
- 1 ≤ n ≤ 1,000,000
- 1 ≤ m ≤ 100,000
- 0 ≤ a, b ≤ n
- a와 b는 정수이고 같을 수도 있다.

## 예제
### 입력
```shell
7 8
0 1 3
1 1 7
0 7 6
1 7 1
0 3 7
0 4 2
0 1 1
1 1 1
```
### 출력
```shell
NO
NO
YES
```